### PR TITLE
Update MiPhilipsSmartBulb.js

### DIFF
--- a/Devices/MiPhilipsSmartBulb.js
+++ b/Devices/MiPhilipsSmartBulb.js
@@ -60,7 +60,7 @@ MiPhilipsSmartBulbLight.prototype.getServices = function() {
         .addCharacteristic(Characteristic.ColorTemperature)
         .setProps({
             minValue: 50,
-            maxValue: 400,
+            maxValue: 5700,
             minStep: 1
         })
         .on('get', this.getColorTemperature.bind(this))


### PR DESCRIPTION
fix This plugin generated a warning from the characteristic 'Color Temperature': characteristic was supplied illegal value